### PR TITLE
Add Java lead CV template and GitHub Pages instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Java Lead CV Template
+
+This project provides a minimalist CV template for **Java Team Leads**, **Java Tech Leads** and **Java Architects**. It uses semantic **HTML5** and modern **CSS3** styling and is ready to be served by GitHub Pages.
+
+## Getting started
+
+1. Clone or fork this repository.
+2. Edit `index.html` with your personal information.
+3. Commit your changes and push to the `main` branch.
+4. In your repository settings on GitHub, enable **GitHub Pages** and choose the `main` branch with the root folder.
+5. Your CV will be available at `https://<username>.github.io/<repository>/`.
+
+Feel free to tweak `styles.css` to match your branding or preferences.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Java Team Lead CV</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Full Name</h1>
+    <p class="role">Java Team Lead / Java Tech Lead / Java Architect</p>
+    <address>
+      <a href="mailto:email@example.com">email@example.com</a> |
+      <a href="https://github.com/username">github.com/username</a> |
+      <a href="https://linkedin.com/in/username">linkedin.com/in/username</a>
+    </address>
+  </header>
+  <main>
+    <section id="summary">
+      <h2>Summary</h2>
+      <p>Brief overview of experience and achievements.</p>
+    </section>
+    <section id="skills">
+      <h2>Skills</h2>
+      <ul>
+        <li>Java, Spring, Spring Boot</li>
+        <li>Microservices, REST APIs</li>
+        <li>Cloud platforms (AWS, GCP)</li>
+        <li>Team leadership, Agile methodologies</li>
+      </ul>
+    </section>
+    <section id="experience">
+      <h2>Professional Experience</h2>
+      <article>
+        <h3>Company Name <span>Location</span> <time>YYYY – YYYY</time></h3>
+        <p class="position">Senior Java Developer / Team Lead</p>
+        <ul>
+          <li>Leading a team of X developers building Y.</li>
+          <li>Designed architecture for Z using Spring Boot and microservices.</li>
+        </ul>
+      </article>
+    </section>
+    <section id="education">
+      <h2>Education</h2>
+      <p>Degree, University, Year</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> Full Name</p>
+  </footer>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,82 @@
+:root {
+  --primary-color: #2b2d42;
+  --accent-color: #ef233c;
+  --font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-family);
+  line-height: 1.6;
+  color: var(--primary-color);
+  background: #f8f9fa;
+}
+
+header {
+  text-align: center;
+  padding: 2rem 1rem;
+  background: var(--primary-color);
+  color: #fff;
+}
+
+header h1 {
+  margin-bottom: 0.3rem;
+}
+
+header .role {
+  font-size: 1.2rem;
+  font-weight: 300;
+  margin-bottom: 0.5rem;
+}
+
+address {
+  font-style: normal;
+}
+
+address a {
+  color: #fff;
+  margin: 0 0.5rem;
+}
+
+main {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+h2 {
+  border-bottom: 2px solid var(--accent-color);
+  padding-bottom: 0.25rem;
+  margin-bottom: 1rem;
+}
+
+ul {
+  padding-left: 1.2rem;
+}
+
+.position {
+  font-weight: bold;
+}
+
+article h3 {
+  margin-bottom: 0.3rem;
+}
+
+article h3 span,
+article h3 time {
+  font-weight: normal;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: #eee;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- Add HTML5 CV template tailored for Java team leads and architects
- Provide responsive CSS3 styling
- Document how to deploy the CV via GitHub Pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ade9a7184483288afb976f06de902d